### PR TITLE
Fix non-16 bit colourspace issue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  DEP_LV_CONFIG_PATH: /home/runner/work/lvgl-rs/lvgl-rs/examples/include
+  DEP_LV_CONFIG_PATH: /home/runner/work/lv_binding_rust/lv_binding_rust/examples/include
 
 jobs:
   build:

--- a/lvgl/src/display.rs
+++ b/lvgl/src/display.rs
@@ -79,7 +79,7 @@ impl<'a> Display {
             unsafe extern "C" fn(
                 *mut lvgl_sys::lv_disp_drv_t,
                 *const lvgl_sys::lv_area_t,
-                *mut lvgl_sys::lv_color16_t,
+                *mut lvgl_sys::lv_color_t,
             ),
         >,
         rounder_cb: Option<
@@ -232,7 +232,7 @@ impl<'a, const N: usize> DisplayDriver<N> {
             unsafe extern "C" fn(
                 *mut lvgl_sys::_lv_disp_drv_t,
                 *const lvgl_sys::lv_area_t,
-                *mut lvgl_sys::lv_color16_t,
+                *mut lvgl_sys::lv_color_t,
             ),
         >,
         rounder_cb: Option<


### PR DESCRIPTION
Partially remedies #103; ~~crate should now automatically determine the correct colourspace to use~~ small mistake fixed.

~~Should we expose this type publicly also?~~