### PR TITLE
Bump embedded-graphics version. Tested with example under X11

### DIFF
--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 lvgl-sys = { version = "0.6.2", path = "../lvgl-sys" }
 cty = "0.2.2"
-embedded-graphics = { version = "0.7.1", optional = true }
+embedded-graphics = { version = "0.8.0", optional = true }
 cstr_core = { version = "0.2.6", default-features = false, features = ["alloc"] }
 bitflags = "2.0.2"
 paste = "1.0.12"
@@ -78,7 +78,7 @@ lvgl-codegen = { version = "0.6.2", path = "../lvgl-codegen" }
 lvgl-sys = { version = "0.6.2", path = "../lvgl-sys" }
 
 [dev-dependencies]
-embedded-graphics-simulator = "0.4.0"
+embedded-graphics-simulator = "0.5.0"
 
 [[example]]
 name = "app"


### PR DESCRIPTION
This is a very small delta to fix an issue I ran into with different versions of embedded-graphics being pulled in by other crates

* Bump embedded-graphics version to latest release 0.8.0
* Bump embedded-graphics-emulator to corresponding release 0.5.0

Tested with the demo example and X11

```
     Running `target/debug/examples/demo`
[Info]  (0.000, +0)      lv_init: begin         (in lv_obj.c line #102)
[Info]  (0.000, +0)      lv_obj_create: begin   (in lv_obj.c line #206)
[Info]  (0.000, +0)      lv_obj_create: begin   (in lv_obj.c line #206)
[Info]  (0.000, +0)      lv_obj_create: begin   (in lv_obj.c line #206)
Before all widgets: lv_mem_monitor_t { total_size: 1048576, free_cnt: 1, free_size: 923848, free_biggest_size: 923848, used_cnt: 74, max_used: 118580, used_pct: 12, frag_pct: 0 }
[Info]  (0.000, +0)      lv_label_create: begin         (in lv_label.c line #75)
[Info]  (0.000, +0)      lv_label_create: begin         (in lv_label.c line #75)
[Info]  (0.000, +0)      lv_label_create: begin         (in lv_label.c line #75)
[Info]  (0.000, +0)      lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (0.000, +0)      lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (0.000, +0)      lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (0.000, +0)      lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (0.000, +0)      lv_label_create: begin         (in lv_label.c line #75)
[Info]  (10.301, +10301)         lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (10.301, +0)     lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (11.382, +1081)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (11.382, +0)     lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (12.460, +1078)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (13.538, +1078)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (14.620, +1082)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (15.710, +1090)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (16.787, +1077)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (17.864, +1077)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (18.941, +1077)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (20.415, +1474)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (21.493, +1078)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
[Info]  (22.570, +1077)  lv_obj_update_layout: Layout update begin      (in lv_obj_pos.c line #314)
Final part of demo app: lv_mem_monitor_t { total_size: 1048576, free_cnt: 2, free_size: 922136, free_biggest_size: 922112, used_cnt: 106, max_used: 119295, used_pct: 13, frag_pct: 1 }
```

