### PR TITLE
Implement the `Error` trait for our internal error types

### DIFF
--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -52,9 +52,11 @@ use-vendored-config = ["lvgl-sys/use-vendored-config"]
 # on the timer module for usage notes.
 rust_timer = ["lvgl-sys/rust_timer"]
 
-# Enables some unstable features. Currently, only #[cfg_accessible] is used.
+# Enables some unstable features. Currently, #![feature(cfg_accessible)] and
+# #![feature(error_in_core)] are used.
 # This feature will currently allow:
 # - Using built-in LVGL fonts other than the default
+# - Handling LvErrors/LvResults with error-handling libraries i.e. anyhow
 nightly = []
 
 # Disables auto-initializing LVGL.

--- a/lvgl/src/display.rs
+++ b/lvgl/src/display.rs
@@ -7,6 +7,9 @@ use core::mem::{ManuallyDrop, MaybeUninit};
 use core::pin::Pin;
 use core::ptr::NonNull;
 use core::{ptr, result};
+use core::fmt;
+#[cfg(feature = "nightly")]
+use core::error::Error;
 
 /// Error in interacting with a `Display`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -15,6 +18,19 @@ pub enum DisplayError {
     FailedToRegister,
     NotRegistered,
 }
+
+impl fmt::Display for DisplayError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Display {}", match self {
+            DisplayError::NotAvailable => "not available",
+            DisplayError::FailedToRegister => "failed to register",
+            DisplayError::NotRegistered => "not registered",
+        })
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl Error for DisplayError {}
 
 type Result<T> = result::Result<T, DisplayError>;
 

--- a/lvgl/src/lib.rs
+++ b/lvgl/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_accessible))]
+#![cfg_attr(feature = "nightly", feature(error_in_core))]
 
 #[macro_use]
 extern crate bitflags;

--- a/lvgl/src/support.rs
+++ b/lvgl/src/support.rs
@@ -2,7 +2,9 @@ use crate::display::DisplayError;
 use crate::Widget;
 use core::convert::{TryFrom, TryInto};
 use core::ptr::NonNull;
-
+use core::fmt;
+#[cfg(feature = "nightly")]
+use core::error::Error;
 #[cfg(feature = "embedded_graphics")]
 use embedded_graphics::pixelcolor::{Rgb565, Rgb888};
 
@@ -16,6 +18,20 @@ pub enum LvError {
     LvOOMemory,
     AlreadyInUse,
 }
+
+impl fmt::Display for LvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", match self {
+            LvError::InvalidReference => "Accessed invalid reference or ptr",
+            LvError::Uninitialized => "LVGL uninitialized",
+            LvError::LvOOMemory => "LVGL out of memory",
+            LvError::AlreadyInUse => "Resource already in use",
+        })
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl Error for LvError {}
 
 impl From<DisplayError> for LvError {
     fn from(err: DisplayError) -> Self {


### PR DESCRIPTION
This feature is nightly-only so I was hesitant to add but since we already have a `nightly` feature I figured it's okay. Will make working with e.g. `anyhow` as a consumer a lot simpler.