### PR TITLE
Automatically delete `Obj` and related on drop

### DIFF
--- a/lvgl-codegen/src/lib.rs
+++ b/lvgl-codegen/src/lib.rs
@@ -121,10 +121,10 @@ impl Rusty for LvFunc {
                     }
                 }
 
-                pub fn new() -> crate::LvResult<Self> {
-                    let mut parent = crate::display::get_scr_act()?;
-                    Self::create(&mut parent)
-                }
+                //pub fn new() -> crate::LvResult<Self> {
+                //    let mut parent = crate::display::get_scr_act()?;
+                //    Self::create(&mut parent)
+                //}
 
             });
         }

--- a/lvgl/src/drivers/lv_drv_display.rs
+++ b/lvgl/src/drivers/lv_drv_display.rs
@@ -274,7 +274,7 @@ mod tests {
     fn gtk_test() {
         const HOR_RES: u32 = 240;
         const VER_RES: u32 = 240;
-        tests::initialize_test(false);
+        tests::initialize_test();
         let buffer = DrawBuffer::<{ (HOR_RES * VER_RES) as usize }>::default();
         let _disp = lv_drv_disp_sdl!(buffer, HOR_RES, VER_RES).unwrap();
     }

--- a/lvgl/src/drivers/lv_drv_input.rs
+++ b/lvgl/src/drivers/lv_drv_input.rs
@@ -88,8 +88,10 @@ mod tests {
 
     #[test]
     fn gtk_test() {
-        tests::initialize_test(true);
-        let disp = Display::default();
+        tests::initialize_test();
+        const REFRESH_BUFFER_SIZE: usize = 240 * 240 / 10;
+        let buffer = DrawBuffer::<REFRESH_BUFFER_SIZE>::default();
+        let disp = Display::register(buffer, 240, 240, |_| {}).unwrap();
         let _input = lv_drv_input_pointer_sdl!(disp);
     }
 }

--- a/lvgl/src/functions.rs
+++ b/lvgl/src/functions.rs
@@ -1,6 +1,6 @@
 use crate::display::{Display, DisplayDriver};
 use crate::input_device::InputDriver;
-use crate::{Event, LvError, LvResult, Obj, Widget};
+use crate::{Event, LvError, LvResult, Widget};
 use core::ptr::NonNull;
 #[cfg(not(feature = "rust_timer"))]
 use core::time::Duration;
@@ -36,19 +36,6 @@ pub(crate) fn disp_get_default() -> Result<Display> {
         NonNull::new(disp_ptr).ok_or(CoreError::OperationFailed)?,
         None,
     ))
-}
-
-pub(crate) fn get_str_act(disp: Option<&Display>) -> Result<Obj> {
-    let scr_ptr = unsafe {
-        lvgl_sys::lv_disp_get_scr_act(
-            disp.map(|d| d.disp.as_ptr())
-                .unwrap_or(ptr::null_mut() as *mut lvgl_sys::lv_disp_t),
-        )
-    };
-    match unsafe { Obj::from_raw(NonNull::new(scr_ptr).ok_or(CoreError::ResourceNotAvailable)?) } {
-        Some(o) => Ok(o),
-        None => Err(CoreError::OperationFailed),
-    }
 }
 
 /// Runs an LVGL tick lasting a given `core::time::Duration`. This function

--- a/lvgl/src/input_device/encoder.rs
+++ b/lvgl/src/input_device/encoder.rs
@@ -173,7 +173,7 @@ unsafe extern "C" fn feedback(_indev_drv: *mut lvgl_sys::lv_indev_drv_t, _code: 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Display;
+    use crate::{Display, DrawBuffer};
     use core::marker::PhantomData;
     use embedded_graphics::draw_target::DrawTarget;
     use embedded_graphics::geometry::Size;
@@ -214,8 +214,10 @@ mod test {
 
     #[test]
     fn encoder_input_device() {
-        crate::tests::initialize_test(true);
-        let display = Display::default();
+        crate::tests::initialize_test();
+        const REFRESH_BUFFER_SIZE: usize = 240 * 240 / 10;
+        let buffer = DrawBuffer::<REFRESH_BUFFER_SIZE>::default();
+        let display = Display::register(buffer, 240, 240, |_| {}).unwrap();
 
         fn read_encoder_device() -> BufferStatus {
             EncoderInputData::Press.pressed().once()

--- a/lvgl/src/input_device/pointer.rs
+++ b/lvgl/src/input_device/pointer.rs
@@ -178,7 +178,7 @@ unsafe extern "C" fn feedback(_indev_drv: *mut lvgl_sys::lv_indev_drv_t, _code: 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Display;
+    use crate::{Display, DrawBuffer};
     use core::marker::PhantomData;
     use embedded_graphics::draw_target::DrawTarget;
     use embedded_graphics::geometry::Size;
@@ -219,8 +219,10 @@ mod test {
 
     #[test]
     fn pointer_input_device() {
-        crate::tests::initialize_test(true);
-        let display = Display::default();
+        crate::tests::initialize_test();
+        const REFRESH_BUFFER_SIZE: usize = 240 * 240 / 10;
+        let buffer = DrawBuffer::<REFRESH_BUFFER_SIZE>::default();
+        let display = Display::register(buffer, 240, 240, |_| {}).unwrap();
 
         fn read_touchpad_device() -> BufferStatus {
             PointerInputData::Touch(Point::new(120, 23))

--- a/lvgl/src/lib.rs
+++ b/lvgl/src/lib.rs
@@ -114,15 +114,8 @@ fn once_init() {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::display::{Display, DrawBuffer};
-
-    pub(crate) fn initialize_test(buf: bool) {
+    pub(crate) fn initialize_test() {
         unsafe { crate::deinit() };
         crate::init();
-        if buf {
-            const REFRESH_BUFFER_SIZE: usize = 240 * 240 / 10;
-            let buffer = DrawBuffer::<REFRESH_BUFFER_SIZE>::default();
-            let _ = Display::register(buffer, 240, 240, |_| {}).unwrap();
-        }
     }
 }

--- a/lvgl/src/lv_core/group.rs
+++ b/lvgl/src/lv_core/group.rs
@@ -26,7 +26,7 @@ impl Group {
     }
 
     /// Adds an object to the group.
-    pub fn add_obj(&mut self, obj: &impl NativeObject) -> LvResult<()> {
+    pub fn add_obj(&mut self, obj: &mut impl NativeObject) -> LvResult<()> {
         unsafe { lvgl_sys::lv_group_add_obj(self.raw()?.as_mut(), obj.raw().as_mut()) }
         Ok(())
     }
@@ -64,12 +64,12 @@ mod test {
     fn group_test() {
         const HOR_RES: u32 = 240;
         const VER_RES: u32 = 240;
-        crate::tests::initialize_test(false);
+        crate::tests::initialize_test();
         let buffer = DrawBuffer::<{ (HOR_RES * VER_RES) as usize }>::default();
         let display = Display::register(buffer, HOR_RES, VER_RES, |_| {}).unwrap();
         let mut screen = display.get_scr_act().unwrap();
         let mut group = Group::default();
-        let btn = Btn::create(&mut screen).unwrap();
-        group.add_obj(&btn).unwrap();
+        let mut btn = Btn::create(&mut screen).unwrap();
+        group.add_obj(&mut btn).unwrap();
     }
 }

--- a/lvgl/src/lv_core/screen.rs
+++ b/lvgl/src/lv_core/screen.rs
@@ -69,7 +69,7 @@ mod test {
     fn screen_test() {
         const HOR_RES: u32 = 240;
         const VER_RES: u32 = 240;
-        crate::tests::initialize_test(false);
+        crate::tests::initialize_test();
         let buffer = DrawBuffer::<{ (HOR_RES * VER_RES) as usize }>::default();
         let display = Display::register(buffer, HOR_RES, VER_RES, |_| {}).unwrap();
         let mut screen_old = display.get_scr_act().unwrap();

--- a/lvgl/src/mem.rs
+++ b/lvgl/src/mem.rs
@@ -127,7 +127,7 @@ mod test {
 
     #[test]
     fn place_value_in_lv_mem() {
-        tests::initialize_test(false);
+        tests::initialize_test();
 
         let v = Box::new(5);
         drop(v);
@@ -137,7 +137,7 @@ mod test {
 
     #[test]
     fn place_complex_value_in_lv_mem() {
-        tests::initialize_test(false);
+        tests::initialize_test();
 
         #[repr(C)]
         #[derive(Debug)]
@@ -189,7 +189,7 @@ mod test {
 
     #[test]
     fn clone_object_in_lv_mem() {
-        crate::tests::initialize_test(false);
+        crate::tests::initialize_test();
 
         let v1 = Box::new(5);
         let v2 = v1.clone();

--- a/lvgl/src/misc/anim.rs
+++ b/lvgl/src/misc/anim.rs
@@ -127,12 +127,14 @@ where
 mod test {
     use super::*;
     use crate::widgets::Btn;
-    use crate::Display;
+    use crate::{Display, DrawBuffer};
 
     #[test]
     fn anim_test() {
-        crate::tests::initialize_test(true);
-        let display = Display::default();
+        crate::tests::initialize_test();
+        const REFRESH_BUFFER_SIZE: usize = 240 * 240 / 10;
+        let buffer = DrawBuffer::<REFRESH_BUFFER_SIZE>::default();
+        let display = Display::register(buffer, 240, 240, |_| {}).unwrap();
         let mut screen = display.get_scr_act().unwrap();
         let mut btn = Btn::create(&mut screen).unwrap();
         let mut anim =


### PR DESCRIPTION
Yet more work towards #140, currently very broken and will require removing some quality-of-life functions i.e. `new()`.