### PR TITLE
Cross compile fixes

### DIFF
--- a/lvgl-sys/Cargo.toml
+++ b/lvgl-sys/Cargo.toml
@@ -32,6 +32,8 @@ cc = "1.0.79"
 bindgen = "0.65.1"
 
 [features]
+library = []
+raw-bindings = []
 use-vendored-config = []
 drivers = []
 rust_timer = []

--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -27,25 +27,52 @@ fn main() {
     let project_dir = canonicalize(PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()));
     let shims_dir = project_dir.join("shims");
     let vendor = project_dir.join("vendor");
+    println!("cargo:rerun-if-env-changed={}", CONFIG_NAME);
+    let lv_config_dir = get_conf_path(&vendor);
+    let font_extra_src: Option<PathBuf> = get_font_extra_dir();
+    if let Some(p) = &font_extra_src {
+        println!("cargo:rerun-if-changed={}", p.to_str().unwrap())
+    }
+
+    let conf = BuildConf {
+        lv_config_dir: lv_config_dir.as_path(),
+        vendor: vendor.as_path(),
+        shims_dir: &shims_dir,
+        font_extra_src: font_extra_src.as_ref().map(PathBuf::as_path),
+    };
+
+    compile_library(&conf);
+    generate_bindings(&conf);
+}
+
+fn get_font_extra_dir() -> Option<PathBuf> {
+    if let Ok(v) = env::var("PWD") {
+        let current_dir = canonicalize(PathBuf::from(v));
+        if let Ok(p) = env::var("LVGL_FONTS_DIR") {
+            Some(canonicalize(PathBuf::from(p)))
+        } else if current_dir.join("fonts").exists() {
+            Some(current_dir.join("fonts"))
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+struct BuildConf<'a> {
+    lv_config_dir: &'a Path,
+    vendor: &'a Path,
+    shims_dir: &'a Path,
+    font_extra_src: Option<&'a Path>,
+}
+
+fn compile_library(conf: &BuildConf) {
+    let vendor = conf.vendor;
+
     let lvgl_src = vendor.join("lvgl").join("src");
     #[cfg(feature = "rust_timer")]
     let timer_shim = vendor.join("include").join("timer");
-
-    let font_extra_src: Option<PathBuf>;
-    if let Ok(v) = env::var("PWD") {
-        let current_dir = canonicalize(PathBuf::from(v));
-        font_extra_src = {
-            if let Ok(p) = env::var("LVGL_FONTS_DIR") {
-                Some(canonicalize(PathBuf::from(p)))
-            } else if current_dir.join("fonts").exists() {
-                Some(current_dir.join("fonts"))
-            } else {
-                None
-            }
-        };
-    } else {
-        font_extra_src = None
-    }
 
     // Some basic defaults; SDL2 is the only driver enabled in the provided
     // driver config by default
@@ -57,71 +84,6 @@ fn main() {
 
     #[cfg(feature = "drivers")]
     let drivers = vendor.join("lv_drivers");
-    println!("cargo:rerun-if-env-changed={}", CONFIG_NAME);
-    let lv_config_dir = {
-        let conf_path = env::var(CONFIG_NAME)
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                match std::env::var("DOCS_RS") {
-                    Ok(_) => {
-                        // We've detected that we are building for docs.rs
-                        // so let's use the vendored `lv_conf.h` file.
-                        vendor.join("include")
-                    }
-                    Err(_) => {
-                        #[cfg(not(feature = "use-vendored-config"))]
-                        panic!(
-                            "The environment variable {} is required to be defined",
-                            CONFIG_NAME
-                        );
-
-                        #[cfg(feature = "use-vendored-config")]
-                        vendor.join("include")
-                    }
-                }
-            });
-
-        if !conf_path.exists() {
-            panic!(
-                "Directory {} referenced by {} needs to exist",
-                conf_path.to_string_lossy(),
-                CONFIG_NAME
-            );
-        }
-        if !conf_path.is_dir() {
-            panic!("{} needs to be a directory", CONFIG_NAME);
-        }
-        if !conf_path.join("lv_conf.h").exists() {
-            panic!(
-                "Directory {} referenced by {} needs to contain a file called lv_conf.h",
-                conf_path.to_string_lossy(),
-                CONFIG_NAME
-            );
-        }
-        #[cfg(feature = "drivers")]
-        if !conf_path.join("lv_drv_conf.h").exists() {
-            panic!(
-                "Directory {} referenced by {} needs to contain a file called lv_drv_conf.h",
-                conf_path.to_string_lossy(),
-                CONFIG_NAME
-            );
-        }
-
-        if let Some(p) = &font_extra_src {
-            println!("cargo:rerun-if-changed={}", p.to_str().unwrap())
-        }
-
-        println!(
-            "cargo:rerun-if-changed={}",
-            conf_path.join("lv_conf.h").to_str().unwrap()
-        );
-        #[cfg(feature = "drivers")]
-        println!(
-            "cargo:rerun-if-changed={}",
-            conf_path.join("lv_drv_conf.h").to_str().unwrap()
-        );
-        conf_path
-    };
 
     #[cfg(feature = "drivers")]
     {
@@ -130,11 +92,11 @@ fn main() {
     }
 
     let mut cfg = Build::new();
-    if let Some(p) = &font_extra_src {
+    if let Some(p) = conf.font_extra_src {
         add_c_files(&mut cfg, p)
     }
     add_c_files(&mut cfg, &lvgl_src);
-    add_c_files(&mut cfg, &shims_dir);
+    add_c_files(&mut cfg, conf.shims_dir);
     #[cfg(feature = "drivers")]
     add_c_files(&mut cfg, &drivers);
 
@@ -142,8 +104,8 @@ fn main() {
         .include(&lvgl_src)
         .include(&vendor)
         .warnings(false)
-        .include(&lv_config_dir);
-    if let Some(p) = &font_extra_src {
+        .include(conf.lv_config_dir);
+    if let Some(p) = conf.font_extra_src {
         cfg.includes(p);
     }
     #[cfg(feature = "rust_timer")]
@@ -155,12 +117,19 @@ fn main() {
 
     cfg.compile("lvgl");
 
+    #[cfg(feature = "drivers")]
+    link_extra.split(',').for_each(|a| {
+        println!("cargo:rustc-link-lib={a}");
+        //println!("cargo:rustc-link-search=")
+    });
+}
+fn generate_bindings(conf: &BuildConf) {
     let mut cc_args = vec![
         "-DLV_CONF_INCLUDE_SIMPLE=1",
         "-I",
-        lv_config_dir.to_str().unwrap(),
+        conf.lv_config_dir.to_str().unwrap(),
         "-I",
-        vendor.to_str().unwrap(),
+        conf.vendor.to_str().unwrap(),
         "-fvisibility=default",
     ];
 
@@ -213,11 +182,11 @@ fn main() {
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let bindings =
-        bindgen::Builder::default().header(shims_dir.join("lvgl_sys.h").to_str().unwrap());
-    let bindings = add_font_headers(bindings, &font_extra_src);
+        bindgen::Builder::default().header(conf.shims_dir.join("lvgl_sys.h").to_str().unwrap());
+    let bindings = add_font_headers(bindings, conf.font_extra_src);
     #[cfg(feature = "drivers")]
     let bindings = bindings
-        .header(shims_dir.join("lvgl_drv.h").to_str().unwrap())
+        .header(conf.shims_dir.join("lvgl_drv.h").to_str().unwrap())
         .parse_callbacks(Box::new(ignored_macros));
     //#[cfg(feature = "rust_timer")]
     //let bindings = bindings.header(shims_dir.join("rs_timer.h").to_str().unwrap());
@@ -235,21 +204,73 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Can't write bindings!");
-
-    #[cfg(feature = "drivers")]
-    link_extra.split(',').for_each(|a| {
-        println!("cargo:rustc-link-lib={a}");
-        //println!("cargo:rustc-link-search=")
-    })
 }
 
-fn add_font_headers(
-    bindings: bindgen::Builder,
-    dir: &Option<impl AsRef<Path>>,
-) -> bindgen::Builder {
+fn get_conf_path(vendor: &PathBuf) -> PathBuf {
+    let conf_path = env::var(CONFIG_NAME)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            match std::env::var("DOCS_RS") {
+                Ok(_) => {
+                    // We've detected that we are building for docs.rs
+                    // so let's use the vendored `lv_conf.h` file.
+                    vendor.join("include")
+                }
+                Err(_) => {
+                    #[cfg(not(feature = "use-vendored-config"))]
+                    panic!(
+                        "The environment variable {} is required to be defined",
+                        CONFIG_NAME
+                    );
+
+                    #[cfg(feature = "use-vendored-config")]
+                    vendor.join("include")
+                }
+            }
+        });
+
+    if !conf_path.exists() {
+        panic!(
+            "Directory {} referenced by {} needs to exist",
+            conf_path.to_string_lossy(),
+            CONFIG_NAME
+        );
+    }
+    if !conf_path.is_dir() {
+        panic!("{} needs to be a directory", CONFIG_NAME);
+    }
+    if !conf_path.join("lv_conf.h").exists() {
+        panic!(
+            "Directory {} referenced by {} needs to contain a file called lv_conf.h",
+            conf_path.to_string_lossy(),
+            CONFIG_NAME
+        );
+    }
+    #[cfg(feature = "drivers")]
+    if !conf_path.join("lv_drv_conf.h").exists() {
+        panic!(
+            "Directory {} referenced by {} needs to contain a file called lv_drv_conf.h",
+            conf_path.to_string_lossy(),
+            CONFIG_NAME
+        );
+    }
+
+    println!(
+        "cargo:rerun-if-changed={}",
+        conf_path.join("lv_conf.h").to_str().unwrap()
+    );
+    #[cfg(feature = "drivers")]
+    println!(
+        "cargo:rerun-if-changed={}",
+        conf_path.join("lv_drv_conf.h").to_str().unwrap()
+    );
+    conf_path
+}
+
+fn add_font_headers(bindings: bindgen::Builder, dir: Option<&Path>) -> bindgen::Builder {
     if let Some(p) = dir {
         let mut temp = bindings;
-        for e in p.as_ref().read_dir().unwrap() {
+        for e in p.read_dir().unwrap() {
             let e = e.unwrap();
             let path = e.path();
             if !e.file_type().unwrap().is_dir()

--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -57,7 +57,7 @@ fn main() {
 
     #[cfg(feature = "drivers")]
     let drivers = vendor.join("lv_drivers");
-
+    println!("cargo:rerun-if-env-changed={}", CONFIG_NAME);
     let lv_config_dir = {
         let conf_path = env::var(CONFIG_NAME)
             .map(PathBuf::from)
@@ -134,7 +134,6 @@ fn main() {
         add_c_files(&mut cfg, p)
     }
     add_c_files(&mut cfg, &lvgl_src);
-    add_c_files(&mut cfg, &lv_config_dir);
     add_c_files(&mut cfg, &shims_dir);
     #[cfg(feature = "drivers")]
     add_c_files(&mut cfg, &drivers);

--- a/lvgl-sys/src/lib.rs
+++ b/lvgl-sys/src/lib.rs
@@ -7,10 +7,12 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+#[cfg(feature = "raw-bindings")]
 pub fn _bindgen_raw_src() -> &'static str {
     include_str!(concat!(env!("OUT_DIR"), "/bindings.rs"))
 }
 
+#[cfg(feature = "library")]
 mod string_impl;
 
 #[cfg(test)]

--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["littlevgl", "lvgl", "graphical_interfaces"]
 build = "build.rs"
 
 [dependencies]
-lvgl-sys = { version = "0.6.2", path = "../lvgl-sys" }
+lvgl-sys = { version = "0.6.2", path = "../lvgl-sys", features = ["library"]}
 cty = "0.2.2"
 embedded-graphics = { version = "0.8.0", optional = true }
 cstr_core = { version = "0.2.6", default-features = false, features = ["alloc"] }
@@ -77,7 +77,7 @@ unsafe_no_autoinit = []
 quote = "1.0.23"
 proc-macro2 = "1.0.51"
 lvgl-codegen = { version = "0.6.2", path = "../lvgl-codegen" }
-lvgl-sys = { version = "0.6.2", path = "../lvgl-sys" }
+lvgl-sys = { version = "0.6.2", path = "../lvgl-sys", features = ["raw-bindings"]}
 
 [dev-dependencies]
 embedded-graphics-simulator = "0.5.0"


### PR DESCRIPTION
Fixes #102

When cross-compiling this library (in my case for ESP32 but the fixes are generic) I came across several issues. This pull requests should fix these.

`lvgl-sys` is built twice, once as a normal dependency for `lvgl` (for the application) and once as build dependency (for the build script executable of lvgl crate). The normal dependency includes the automatically generated bindings (built by bindgen) and links the lvgl C library itself (using the cc crate). The build dependency is used to call `_bindgen_raw_src` to retrieve the raw source code of the generated bindings to further autogenerate rust code.

Both the library and the bindings are generated twice, for the application and build script. For the application the target (TARGET env) is set correctly, however the build script is a host targeted executable (TARGET == HOST), so the library and bindings are actually generated for the host machine. The library itself is not used for the build executable so this problem is silent, it does take unnecessary time to compile though. The bindings however are used in the build host executable, but here the bindings should be compiled for the target machine and not for the host. In most cases these bindings will be the same but there may be subtle differences leading to bugs. For both the application and the build script, the bindings need to be targeted to the embedded device.

Since HOST == TARGET in the build script, there is no way to tell the actual application target. The cc crate allows the environment variable `CROSS_COMPILE` to be set to specify a different compiler. It is only used by cc when host != target though. Bindgen does not use this variable, also it needs to cross-compile even when host == target so in this case target should always be CROSS_COMPILE.

While figuring this out I also came across a slightly unrelated issue with this line in lvlg-sys build.rs:
`add_c_files(&mut cfg, &lv_config_dir);`
This actually compiles *all* c files recursively starting at the config dir. Since the config dir is often the project dir this causes the script to possibly build all kinds of unrelated files. Especially with esp32 which stores the c source of esp-idf in a some directory in the project. I removed this line since the documentation says nothing about compiling C files from the config dir. If this is required for someone it should probably be a separate env var.

This PR consists of 3 commits:
[Remove compilation of all recursive C files in config dir ](https://github.com/lvgl/lv_binding_rust/commit/4f3fdd8e49f8cd9d286fdc50994c1f6a4eac36be)
Removes the add_c_files line for the config and adds a missing rerun-if-env-changed for the config env var.

[Refactor build script: separate library and bindings in separate functions](https://github.com/lvgl/lv_binding_rust/commit/aa883057d7a9556542c023c1ecb22495208ded48)
Lots of changed lines but actually changes no functionality, just refactors the build script in two separate steps and cleans it up a bit

[Add library and raw-bindings features to lvgl-sys](https://github.com/lvgl/lv_binding_rust/commit/4f3fdd8e49f8cd9d286fdc50994c1f6a4eac36be)
The `library` feature switches the compilation (cc) of the library on or off
The `raw-bindings` feature toggles `_bindgen_raw_src`
- The normal dependency on lvgl-sys enables the library feature: library and bindings compiled (cc+bindgen) for the target application, no raw bindings needed
- The build dependency enables only raw-bindings: library not compiled (no cc), raw bindings generated for build step
- `generate_bindings` is modified to prefer CROSS_COMPILE over TARGET in all cases, so that bindings are generated for the correct target in both the build and application step. 

This fixes the build for ESP32 (checked that it at least compiles for no-std and std esp templates) and it still works on linux with SDL (tested). 

For ESP32 (and other embedded targets), the CROSS_COMPILE variable needs to be set, for example for esp32s3 you would need `export CROSS_COMPILE=xtensa-esp32s3-elf`, or better include it as `[env]` in `.cargo/config.toml`
Another issue is that bindgen (at least for ESP32) does not have a sysroot by default. This can be set using `export BINDGEN_EXTRA_CLANG_ARGS="--sysroot directoryhere"`. To find the correct sysroot you can run one of the gcc compiler tools with `--print-sysroot`, though cc does not work so use ld for example:  `xtensa-esp32s3-elf-ld --print-sysroot`.

Or if CROSS_COMPILE is available in one go:
```
export CROSS_COMPILE=xtensa-esp32s3-elf
export BINDGEN_EXTRA_CLANG_ARGS="--sysroot "`$CROSS_COMPILE-ld --print-sysroot`
```

The bindgen sysroot could be done by the build.rs script as well but maybe that's a bit too specific.
