### PR TITLE
Fix including fonts when building lvgl-sys

### DIFF
--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -145,7 +145,7 @@ fn main() {
         .warnings(false)
         .include(&lv_config_dir);
     if let Some(p) = &font_extra_src {
-        cfg.includes(p);
+        cfg.include(p);
     }
     #[cfg(feature = "rust_timer")]
     cfg.include(&timer_shim);


### PR DESCRIPTION
Before fix:
`"-I" "/" "-I" "home" "-I" "jmjoy" "-I" "workspace" "-I" "rust" "-I" "lv_binding_rust" "-I" "fonts"`

After fix:
`"-I" "/home/jmjoy/workspace/rust/lv_binding_rust/fonts"`