### PR TITLE
fix: fixed compile-time errors during cross-compiling

### DIFF
--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -153,11 +153,13 @@ fn main() {
     cfg.include(&drivers);
     #[cfg(feature = "drivers")]
     cfg.includes(incl_extra.split(','));
-
+    cfg.includes(["/usr/include", "/usr/local/include"]);
     cfg.compile("lvgl");
 
-    let mut cc_args = vec![
+    let cc_args = vec![
         "-DLV_CONF_INCLUDE_SIMPLE=1",
+        "-I/usr/include",
+        "-I/usr/local/include",
         "-I",
         lv_config_dir.to_str().unwrap(),
         "-I",
@@ -167,11 +169,6 @@ fn main() {
 
     // Set correct target triple for bindgen when cross-compiling
     let target = env::var("TARGET").expect("Cargo build scripts always have TARGET");
-    let host = env::var("HOST").expect("Cargo build scripts always have HOST");
-    if target != host {
-        cc_args.push("-target");
-        cc_args.push(target.as_str());
-    }
 
     let mut additional_args = Vec::new();
     if target.ends_with("emscripten") {


### PR DESCRIPTION
## Delete Target specification
[This part of the code](https://github.com/rust-lang/rust-bindgen/blob/main/bindgen/lib.rs#L748)  tells us that calling bingen in the build script will automatically check TARGET and generate the corresponding clang_args without us having to enter it ourselves. And typing clang_args ourselves will cause problems. For example, when `riscv64gc-unknown-none-elf` is used as the target, the corresponding value in clang should be `--target riscv64-unknown-none-elf` instead of `--target riscv64gc-unknown-none-elf` , and this escaping operation is performed in bindgen, but if we specify  `--target riscv64gc-unknown-none-elf`  through `clang_args`, this escaping logic will be skipped([details here](https://github.com/rust-lang/rust-bindgen/blob/main/bindgen/lib.rs#L735)), making it impossible to generate the correct `clang_args`

## Add include path
In cross compilation, errors such as `<inttype>not found` always appeared, and I found that this was due to the include path problem. When the driver feature is not turned on, the include path may not contain `/usr/include, /usr/local/include`. After my testing, even adding these two paths to the PATH environment variable will not take effect. I It was found that only by adding these two paths to `build.rs` can the compilation pass smoothly.