### PR TITLE
fix: gate tick_inc function by feature custom_timer

### DIFF
--- a/lvgl-sys/Cargo.toml
+++ b/lvgl-sys/Cargo.toml
@@ -35,3 +35,5 @@ bindgen = "0.65.1"
 use-vendored-config = []
 drivers = []
 rust_timer = []
+# if LV_TICK_CUSTOM = 1, then lv_tick_inc function is unavailable
+custom_timer = []

--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -52,6 +52,9 @@ use-vendored-config = ["lvgl-sys/use-vendored-config"]
 # on the timer module for usage notes.
 rust_timer = ["lvgl-sys/rust_timer"]
 
+# Enables using a custom tick function supplied in lv_conf.h
+custom_timer = ["lvgl-sys/custom_timer"]
+
 # Enables some unstable features. Currently, #![feature(cfg_accessible)] and
 # #![feature(error_in_core)] are used.
 # This feature will currently allow:

--- a/lvgl/src/functions.rs
+++ b/lvgl/src/functions.rs
@@ -54,7 +54,7 @@ pub(crate) fn get_str_act(disp: Option<&Display>) -> Result<Obj> {
 /// Runs an LVGL tick lasting a given `core::time::Duration`. This function
 /// should be called periodically.
 #[inline]
-#[cfg(not(feature = "rust_timer"))]
+#[cfg(not(any(feature = "rust_timer", feature = "custom_timer")))]
 pub fn tick_inc(tick_period: Duration) {
     unsafe {
         lvgl_sys::lv_tick_inc(tick_period.as_millis() as u32);


### PR DESCRIPTION
lv_tick_inc function is available only when default (non-custom) timer implementation is used.

This patch fixes building the bindings in that case.