### PR TITLE
sys/build: honor LVGL_INCLUDE even w/o drivers feature

### DIFF
--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -49,7 +49,6 @@ fn main() {
 
     // Some basic defaults; SDL2 is the only driver enabled in the provided
     // driver config by default
-    #[cfg(feature = "drivers")]
     let incl_extra =
         env::var("LVGL_INCLUDE").unwrap_or("/usr/include,/usr/local/include".to_string());
     #[cfg(feature = "drivers")]
@@ -151,7 +150,6 @@ fn main() {
     cfg.include(&timer_shim);
     #[cfg(feature = "drivers")]
     cfg.include(&drivers);
-    #[cfg(feature = "drivers")]
     cfg.includes(incl_extra.split(','));
 
     cfg.compile("lvgl");


### PR DESCRIPTION
In real-world scenarios it's usually requried to pass more include paths to lvgl then cargo/bindgen does by default.
It's certainly true in my case.