### PR TITLE
feat: accept additional cflags from LVGL_CFLAGS env var

### DIFF
--- a/lvgl-sys/build.rs
+++ b/lvgl-sys/build.rs
@@ -52,6 +52,10 @@ fn main() {
     #[cfg(feature = "drivers")]
     let incl_extra =
         env::var("LVGL_INCLUDE").unwrap_or("/usr/include,/usr/local/include".to_string());
+
+    let cflags_extra = env::var("LVGL_CFLAGS").unwrap_or_default();
+    let cflags_extra = cflags_extra.split(',');
+
     #[cfg(feature = "drivers")]
     let link_extra = env::var("LVGL_LINK").unwrap_or("SDL2".to_string());
 
@@ -154,6 +158,11 @@ fn main() {
     #[cfg(feature = "drivers")]
     cfg.includes(incl_extra.split(','));
 
+    cflags_extra.clone().for_each(|e| {
+        let mut it = e.split('=');
+        cfg.define(it.next().unwrap(), it.next().unwrap_or_default());
+    });
+
     cfg.compile("lvgl");
 
     let mut cc_args = vec![
@@ -230,6 +239,7 @@ fn main() {
         .ctypes_prefix("cty")
         .clang_args(&cc_args)
         .clang_args(&additional_args)
+        .clang_args(cflags_extra.map(|f| format!("-D{f}")))
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
Allow passing more flags beyond what rust build system can pass.