### PR TITLE
Add custom allocator feature

### DIFF
--- a/lvgl/Cargo.toml
+++ b/lvgl/Cargo.toml
@@ -73,6 +73,9 @@ nightly = []
 # function before constructing or using anything LVGL-related.
 unsafe_no_autoinit = []
 
+# This feature is required to use the custom allocator in lvgl (`LV_MEM_CUSTOM=1` in `lv_conf.h`).
+custom_allocator = []
+
 [build-dependencies]
 quote = "1.0.23"
 proc-macro2 = "1.0.51"

--- a/lvgl/src/lib.rs
+++ b/lvgl/src/lib.rs
@@ -97,6 +97,7 @@ pub fn init() {
 ///
 /// After calling, ensure existing LVGL-related values are not accessed even if
 /// LVGL is reinitialized.
+#[cfg(not(feature = "custom_allocator"))]
 pub unsafe fn deinit() {
     unsafe {
         if IS_INIT {


### PR DESCRIPTION
This feature is necessary when `LV_MEM_CUSTOM=1` because `lv_deinit()` is not defined in this scenario :

```
error[E0425]: cannot find function `lv_deinit` in crate `lvgl_sys`
    --> /home/alix_anneraud/.cargo/git/checkouts/lv_binding_rust-d86feb7597e107b7/9829aef/lvgl/src/lib.rs:103:23
     |
103  |             lvgl_sys::lv_deinit();
     |                       ^^^^^^^^^ help: a function with a similar name exists: `lv_init`
     |
    ::: /home/alix_anneraud/Git/Personnel/Xila/New-Code/target/debug/build/lvgl-sys-927f327e46b48320/out/bindings.rs:7701:5
     |
7701 |     pub fn lv_init();
     |     ---------------- similarly named function `lv_init` defined here

For more information about this error, try `rustc --explain E0425`.
error: could not compile `lvgl` (lib) due to 1 previous error
```